### PR TITLE
Update discord version with crash on removal of old messages

### DIFF
--- a/InitiativeBot/Discord/Bot.cs
+++ b/InitiativeBot/Discord/Bot.cs
@@ -53,6 +53,7 @@ namespace Discord
         private async Task ResyncBot()
         {
             Task[] resyncGuildTasks = new Task[_client.Guilds.Count];
+            Log.Information( "Bot present in {Count} guilds", _client.Guilds.Count );
             for (int i = 0; i < _client.Guilds.Count; i++)
             {
                 resyncGuildTasks[i] = ResyncBotInGuild(_client.Guilds.ElementAt(i));

--- a/InitiativeBot/Discord/Constants.cs
+++ b/InitiativeBot/Discord/Constants.cs
@@ -89,7 +89,8 @@ When you add a player that already exists, it will remove the existing one and a
             public const string EmptyListMessage = "_Add new players by using command `/join {name} {modifiers}`_";
             public const string RoundZeroMessage = "__**Before Combat**__\n";
             public const string InCombatRoundMessage = "__**Round: {0}**__\n"; //Should have 1 parameter: round number
-
+            public const string OldMessagesWarning = "This channel has old messages that cannot be easily deleted. You can leave them, but consider purging the channel or removing it to set it up from scratch.";
+            
             public static class Button
             {
                 public const string Label = "Next Turn";

--- a/InitiativeBot/Discord/Discord.csproj
+++ b/InitiativeBot/Discord/Discord.csproj
@@ -8,6 +8,10 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Discord.Net" Version="3.7.2" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.14.0" />

--- a/InitiativeBot/Discord/Discord.csproj
+++ b/InitiativeBot/Discord/Discord.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Discord.Net" Version="3.1.0" />
+    <PackageReference Include="Discord.Net" Version="3.7.2" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.14.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
   </ItemGroup>

--- a/InitiativeBot/Discord/Program.cs
+++ b/InitiativeBot/Discord/Program.cs
@@ -5,6 +5,9 @@ const string token_file = "./token";
 
 Log.Logger = new LoggerConfiguration()
     .WriteTo.Console()
+#if DEBUG
+    .MinimumLevel.Debug()
+#endif
     .CreateLogger();
 
 string? token = Environment.GetEnvironmentVariable(environment_token_variable_name);


### PR DESCRIPTION
The old version of the discord library didn't allow to start of the bot. Additionally, trying to remove old messages caused a crash of setup in the given server, so if the channel had messages older than 14 days, it couldn't be used. Workaround: all messages that can be easily removed are removed, if there are still messages - a warning message with a proposition to purge the channel or completely recreate it is sent.